### PR TITLE
feat: forward options to parser/serializer

### DIFF
--- a/fromFile.js
+++ b/fromFile.js
@@ -3,7 +3,7 @@ const formats = require('@rdfjs/formats-common')
 const { createReadStream } = require('fs')
 const { extname } = require('path')
 
-function fromFile (filename, { extensions = config.extensions } = {}) {
+function fromFile (filename, { extensions = config.extensions, ...options } = {}) {
   const extension = extname(filename).split('.').pop()
   const mediaType = extensions[extension]
 
@@ -17,7 +17,7 @@ function fromFile (filename, { extensions = config.extensions } = {}) {
     throw new Error(`No parser available for media type: ${mediaType}`)
   }
 
-  return parser.import(createReadStream(filename))
+  return parser.import(createReadStream(filename), options)
 }
 
 module.exports = fromFile

--- a/test/fromFile.test.js
+++ b/test/fromFile.test.js
@@ -14,6 +14,15 @@ describe('fromFile', () => {
     expect(equals(dataset, example()))
   })
 
+  it('should forward options to parser', async () => {
+    const stream = fromFile(resolve(__dirname, 'support/example.ttl'))
+    const dataset = await fromStream(rdf.dataset(), stream, {
+      baseIRI: 'http://example.org/'
+    })
+
+    expect(equals(dataset, example()))
+  })
+
   it('should throw an error if the file extension is unknown', () => {
     expect(() => {
       fromFile('test.jpg')

--- a/test/support/example.ttl
+++ b/test/support/example.ttl
@@ -1,0 +1,1 @@
+<subject> <predicate> "object" .

--- a/toFile.js
+++ b/toFile.js
@@ -5,7 +5,7 @@ const { extname } = require('path')
 const { finished } = require('readable-stream')
 const { promisify } = require('util')
 
-function toFile (stream, filename, { extensions = config.extensions } = {}) {
+function toFile (stream, filename, { extensions = config.extensions, ...options } = {}) {
   const extension = extname(filename).split('.').pop()
   const mediaType = extensions[extension]
 
@@ -21,7 +21,7 @@ function toFile (stream, filename, { extensions = config.extensions } = {}) {
 
   const output = createWriteStream(filename)
 
-  serializer.import(stream).pipe(output)
+  serializer.import(stream, options).pipe(output)
 
   return promisify(finished)(output)
 }


### PR DESCRIPTION
For parsing, this allows passing base IRI. Not sure about usefulness with serializer but added for symmetry