### PR TITLE
Improve extensions

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -2,8 +2,12 @@ const defaults = {}
 
 defaults.extensions = {
   json: 'application/ld+json',
+  jsonld: 'application/ld+json',
   nq: 'application/n-quads',
   nt: 'application/n-triples',
+  n3: 'text/turtle',
+  trig: 'application/trig',
+  rdf: 'application/xml+rdf',
   ttl: 'text/turtle'
 }
 

--- a/fromFile.js
+++ b/fromFile.js
@@ -1,11 +1,16 @@
 const { createReadStream } = require('fs')
 const { extname } = require('path')
 const formats = require('@rdfjs/formats-common')
-const config = require('./defaults')
+const defaults = require('./defaults')
 
-function fromFile (filename, { extensions = config.extensions, ...options } = {}) {
+function fromFile (filename, { extensions, ...options } = {}) {
+  const combinedExtensions = {
+    ...defaults.extensions,
+    ...extensions
+  }
+
   const extension = extname(filename).split('.').pop()
-  const mediaType = extensions[extension]
+  const mediaType = combinedExtensions[extension]
 
   if (!mediaType) {
     throw new Error(`Unknown file extension: ${extension}`)

--- a/test/fromFile.test.js
+++ b/test/fromFile.test.js
@@ -19,7 +19,7 @@ describe('fromFile', () => {
     const stream = fromFile(resolve(__dirname, 'support/example.ttl'), { baseIRI: 'http://example.org/' })
     const dataset = await rdf.dataset().import(stream)
 
-    strictEqual(dataset.toCanonical(), example().toCanonical())
+    strictEqual(dataset.toCanonical(), example.defaultGraph().toCanonical())
   })
 
   it('should combine extensions with default', async () => {
@@ -30,8 +30,24 @@ describe('fromFile', () => {
     const stream = fromFile(resolve(__dirname, 'support/example.nt'), { extensions })
     const dataset = await rdf.dataset().import(stream)
 
-    strictEqual(dataset.toCanonical(), example().toCanonical())
+    strictEqual(dataset.toCanonical(), example.defaultGraph().toCanonical())
   })
+
+  const commonExtensions = [
+    ['json', example.defaultGraph],
+    ['jsonld', example.namedGraph],
+    ['n3', example.defaultGraph],
+    ['trig', example.namedGraph],
+    ['nq', example.namedGraph]
+  ]
+  for (const [extension, expected] of commonExtensions) {
+    it(`should load ${extension} out of the box`, async () => {
+      const stream = fromFile(resolve(__dirname, `support/example.${extension}`))
+      const dataset = await rdf.dataset().import(stream)
+
+      strictEqual(dataset.toCanonical(), expected().toCanonical())
+    })
+  }
 
   it('should throw an error if the file extension is unknown', () => {
     throws(() => {

--- a/test/fromFile.test.js
+++ b/test/fromFile.test.js
@@ -22,6 +22,17 @@ describe('fromFile', () => {
     strictEqual(dataset.toCanonical(), example().toCanonical())
   })
 
+  it('should combine extensions with default', async () => {
+    const extensions = {
+      trig: 'application/trig'
+    }
+
+    const stream = fromFile(resolve(__dirname, 'support/example.nt'), { extensions })
+    const dataset = await rdf.dataset().import(stream)
+
+    strictEqual(dataset.toCanonical(), example().toCanonical())
+  })
+
   it('should throw an error if the file extension is unknown', () => {
     throws(() => {
       fromFile('test.jpg')

--- a/test/support/example.js
+++ b/test/support/example.js
@@ -1,6 +1,6 @@
 const rdf = require('rdf-ext')
 
-function example () {
+function defaultGraph () {
   return rdf.dataset([rdf.quad(
     rdf.namedNode('http://example.org/subject'),
     rdf.namedNode('http://example.org/predicate'),
@@ -8,4 +8,16 @@ function example () {
   )])
 }
 
-module.exports = example
+function namedGraph () {
+  return rdf.dataset([rdf.quad(
+    rdf.namedNode('http://example.org/subject'),
+    rdf.namedNode('http://example.org/predicate'),
+    rdf.literal('object'),
+    rdf.namedNode('http://example.org/subject')
+  )])
+}
+
+module.exports = {
+  defaultGraph,
+  namedGraph
+}

--- a/test/support/example.json
+++ b/test/support/example.json
@@ -1,0 +1,4 @@
+{
+  "@id": "http://example.org/subject",
+  "http://example.org/predicate": "object"
+}

--- a/test/support/example.jsonld
+++ b/test/support/example.jsonld
@@ -1,0 +1,9 @@
+{
+  "@graph": [
+    {
+      "@id": "http://example.org/subject",
+      "http://example.org/predicate": "object"
+    }
+  ],
+  "@id": "http://example.org/subject"
+}

--- a/test/support/example.n3
+++ b/test/support/example.n3
@@ -1,0 +1,1 @@
+<http://example.org/subject> <http://example.org/predicate> "object" .

--- a/test/support/example.nq
+++ b/test/support/example.nq
@@ -1,0 +1,1 @@
+<http://example.org/subject> <http://example.org/predicate> "object" <http://example.org/subject> .

--- a/test/support/example.trig
+++ b/test/support/example.trig
@@ -1,0 +1,3 @@
+graph <http://example.org/subject> {
+    <http://example.org/subject> <http://example.org/predicate> "object" .
+}

--- a/test/toFile.test.js
+++ b/test/toFile.test.js
@@ -15,7 +15,7 @@ describe('toFile', () => {
 
   it('should create a quad stream', async () => {
     const filename = 'tmp/test.nt'
-    await toFile(example().toStream(), filename)
+    await toFile(example.defaultGraph().toStream(), filename)
     const content = readFileSync(filename).toString().trim()
     const expected = readFileSync(resolve(__dirname, 'support/example.nt')).toString().trim()
 
@@ -24,13 +24,13 @@ describe('toFile', () => {
 
   it('should throw an error if the file extension is unknown', () => {
     throws(() => {
-      toFile(example().toStream(), 'test.jpg')
+      toFile(example.defaultGraph().toStream(), 'test.jpg')
     })
   })
 
   it('should throw an error if the media type is unknown', () => {
     throws(() => {
-      toFile(example().toStream(), 'test.jpg', {
+      toFile(example.defaultGraph().toStream(), 'test.jpg', {
         extensions: {
           jpg: 'image/jpeg'
         }


### PR DESCRIPTION
This introduces two changes, both of which I consider fixes 😉 

1. When using `extensions` option, it should not overwrite the defaults but merge
2. Added default prefixes for other extensions which can be supported out of the box: `.trig`, `.n3`, `.jsonld` and `.rdf`